### PR TITLE
fix: passed client_id and client_secret as additional parameters.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -139,11 +139,15 @@ Client.prototype.setAccessToken = function(callback) {
 
   if (aToken.expired()) {
     debug('the access token has expired, refreshing');
-    aToken.refresh((error, result) => {
+    aToken.refresh({'client_id': this.config.clientId, 'lient_secret': this.config.clientSecret})
+    .then((result) => {
       aToken = result;
       debug(aToken, 'received a new AccessToken object');
-      this.config.accessToken = aToken.token.access_token;
-      callback(aToken.token);
+      this.config.accessToken = aToken.token.access_token; 
+      callback(aToken.token); 
+    })
+    .catch((error) => {
+      console.error('Error refreshing access token:', error);
     });
   } else {
     callback(aToken.token);


### PR DESCRIPTION
The Upwork [Access Token Request endpoint](https://developers.upwork.com/?lang=python#authentication_access-token-request) requires `client_secret` for `grant_type=refresh_token`. I passed c`client_id` and `client_secret` as additional parameters in the refresh request.